### PR TITLE
Update pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 **Version changelog**
 
-A list of changes regarding the next major version release:
+A list of changes regarding the next version release:
 
 1. Short description of the new feature/fix - #Issue/PR-Number
 2. Short description of the new feature/fix - #Issue/PR-Number


### PR DESCRIPTION
Removes `major` from the changelog description as the PR might not be for only a major version.