### PR TITLE
Zip workflow didn't checkout files to folder

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,13 +12,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: master
-          path: smailyforopencart
+          path: smailyforprestashop
 
       - name: Compress ZIP
         uses: TheDoctor0/zip-release@v0.3.0
         with:
           filename: release.zip
-          path: smailyforopencart
+          path: smailyforprestashop
           exclusions: "*.git* /*.docker/* /*assets/* /*tusk.yml"
 
       - name: Get release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,11 +12,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: master
+          path: smailyforopencart
 
       - name: Compress ZIP
         uses: TheDoctor0/zip-release@v0.3.0
         with:
           filename: release.zip
+          path: smailyforopencart
           exclusions: "*.git* /*.docker/* /*assets/* /*tusk.yml"
 
       - name: Get release


### PR DESCRIPTION
The previous workflow didn't work with Prestashop's module uploader, because the zip file didn't contain a folder called smailyforprestashop.
Now checking code out to a folder, which is compressed to a zip.
Tested it on my fork of the repo and it worked.