### PR TITLE
fix: Fix subscribers not collected by Smaily newsletter form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.6.2
+
+- Fix an issue where conflicting styles with Newsletter Subscription plugin blocked Smaily subscription form post request.
+
 ### 1.6.1
 
 - Update user manual links [[#51](https://github.com/sendsmaily/smaily-prestashop-module/pull/51)]

--- a/src/smailyforprestashop.php
+++ b/src/smailyforprestashop.php
@@ -88,6 +88,7 @@ class SmailyForPrestashop extends Module
             !$this->registerHook('footerBefore') ||
             !$this->registerHook('leftColumn') ||
             !$this->registerHook('rightColumn') ||
+            !$this->registerHook('actionFrontControllerSetMedia') ||
             // User has option to trigger opt-in when customer joins store & newsletter through sign-up.
             !$this->registerHook('actionCustomerAccountAdd')
         ) {
@@ -399,23 +400,40 @@ class SmailyForPrestashop extends Module
         );
     }
 
+    /**
+     * Load CSS and JS files for front controllers.
+     *
+     * @return void
+     */
+    public function hookActionFrontControllerSetMedia()
+    {
+        $this->context->controller->registerStylesheet(
+            'mymodule-style',
+            $this->_path . 'views/css/smaily_newsletter.css',
+            [
+                'media' => 'all',
+                'priority' => 1000,
+            ]
+        );
+    }
+
     // Display Block Newsletter in footer.
     public function hookDisplayFooterBefore($params)
     {
-        // Add subdomain to template.
         $this->context->smarty->assign(array(
             'smaily_subdomain' => pSQL(Configuration::get('SMAILY_SUBDOMAIN')),
         ));
+
         return $this->display(__FILE__, 'smaily_blocknewsletter.tpl');
     }
 
     // Display Block Newsletter in left column.
     public function hookDisplayLeftColumn($params)
     {
-        // Add subdomain to template.
         $this->context->smarty->assign(array(
             'smaily_subdomain' => pSQL(Configuration::get('SMAILY_SUBDOMAIN')),
         ));
+
         return $this->display(__FILE__, 'smaily_blocknewsletter_column.tpl');
     }
 

--- a/src/smailyforprestashop.php
+++ b/src/smailyforprestashop.php
@@ -35,7 +35,7 @@ class SmailyForPrestashop extends Module
         $this->name = 'smailyforprestashop';
         $this->tab = 'advertising_marketing';
         $this->module_key = 'bcea90ce4da2594c0d0179852db9a1e3';
-        $this->version = '1.6.1';
+        $this->version = '1.6.2';
         $this->author = 'Smaily';
         $this->need_instance = 0;
         $this->ps_versions_compliancy = array(

--- a/src/views/css/smaily_newsletter.css
+++ b/src/views/css/smaily_newsletter.css
@@ -1,0 +1,28 @@
+.smaily_block_newsletter {
+    margin-bottom: 0.625rem;
+}
+
+.smaily_block_newsletter p {
+    padding-top: 0.625rem;
+}
+
+.smaily_block_newsletter .input-wrapper {
+    overflow: hidden;
+    font-size: 0.85rem;
+}
+
+.smaily_block_newsletter input[type="email"] {
+    padding: 11px;
+    width: 100%;
+}
+
+.smaily_block_newsletter input[type="email"]:focus {
+    border: 3px solid #2fb5d2;
+    padding: 8px 8px 9px;
+    outline: 0;
+}
+
+.smaily_block_newsletter input {
+    height: 42px;
+    box-shadow: none;
+}

--- a/src/views/templates/hook/smaily_blocknewsletter.tpl
+++ b/src/views/templates/hook/smaily_blocknewsletter.tpl
@@ -20,8 +20,9 @@
  * @copyright 2018 Smaily
  * @license   GPL3
  *}
- {if !empty($smaily_subdomain)}
-    <div class="block_newsletter col-lg-8 col-md-12 col-sm-12">
+
+{if !empty($smaily_subdomain)}
+    <div class="smaily_block_newsletter col-lg-8 col-md-12 col-sm-12">
         <div class="row">
             <p id="smaily-newsletter-label" class="col-md-5 col-xs-12">{l s="Get our latest news and special sales" mod='smailyforprestashop'}</p>
             <div class="col-md-7 col-xs-12">
@@ -33,7 +34,7 @@
                             <input type="hidden" name="language" value="{(isset($language.iso_code)) ? $language.iso_code : ''}" />
                             <input class="btn btn-primary float-xs-right" type="submit" value="{l s="Submit" mod='smailyforprestashop'}" />
                             <div class="input-wrapper">
-                            <input name="email" type="email" value="" placeholder="{l s="Your email address" mod='smailyforprestashop'}" aria-labelledby="block-newsletter-label" required />
+                                <input name="email" type="email" value="" placeholder="{l s="Your email address" mod='smailyforprestashop'}" aria-labelledby="block-newsletter-label" required />
                             </div>
                             <div class="clearfix"></div>
                         </div>
@@ -42,9 +43,9 @@
                             {if isset($smarty.get.message)}
                             <p class="alert {if $smarty.get.code == 101} alert-success {else} alert-danger {/if}">
                                 {if $smarty.get.code == 101}
-                                {l s="Thank you for your subscription!" mod='smailyforprestashop'}
+                                    {l s="Thank you for your subscription!" mod='smailyforprestashop'}
                                 {else}
-                                {l s="Something went wrong with subscription, please try again!" mod='smailyforprestashop'}
+                                    {l s="Something went wrong with subscription, please try again!" mod='smailyforprestashop'}
                                 {/if}
                             </p>
                             {/if}

--- a/src/views/templates/hook/smaily_blocknewsletter_column.tpl
+++ b/src/views/templates/hook/smaily_blocknewsletter_column.tpl
@@ -20,8 +20,9 @@
  * @copyright 2018 Smaily
  * @license   GPL3
  *}
- {if !empty($smaily_subdomain)}
-    <div class="block_newsletter">
+
+{if !empty($smaily_subdomain)}
+    <div class="smaily_block_newsletter">
         <div class="row">
             <p id="smaily-newsletter-label">{l s="Get our latest news and special sales" mod='smailyforprestashop'}</p>
             <div>
@@ -33,7 +34,7 @@
                             <input type="hidden" name="language" value="{(isset($language.iso_code)) ? $language.iso_code : ''}" />
                             <input class="btn btn-primary float-xs-right" type="submit" value="{l s="Submit" mod='smailyforprestashop'}" />
                             <div class="input-wrapper">
-                            <input name="email" type="email" value="" placeholder="{l s="Your email address" mod='smailyforprestashop'}" aria-labelledby="block-newsletter-label" required />
+                                <input name="email" type="email" value="" placeholder="{l s="Your email address" mod='smailyforprestashop'}" aria-labelledby="block-newsletter-label" required />
                             </div>
                             <div class="clearfix"></div>
                         </div>
@@ -42,9 +43,9 @@
                             {if isset($smarty.get.message)}
                             <p class="alert {if $smarty.get.code == 101} alert-success {else} alert-danger {/if}">
                                 {if $smarty.get.code == 101}
-                                {l s="Thank you for your subscription!" mod='smailyforprestashop'}
+                                    {l s="Thank you for your subscription!" mod='smailyforprestashop'}
                                 {else}
-                                {l s="Something went wrong with subscription, please try again!" mod='smailyforprestashop'}
+                                    {l s="Something went wrong with subscription, please try again!" mod='smailyforprestashop'}
                                 {/if}
                             </p>
                             {/if}


### PR DESCRIPTION
Fixes an issue where newsletter subscribers are not sent to Smaily when filling out the subscription form.

# Plugin Version : 1.6.2 (next version number)

**Version changelog**

A list of changes regarding the next version release:

1. Fix an issue where conflicting styles with Newsletter Subscription plugin blocked Smaily subscription form post request.

**Release checklist**

- [ ] Added `release` tag to this pull request
- [ ] Updated README.md
- [x] Updated CHANGELOG.md
- [ ] Updated USERGUIDE.md
- [ ] Updated CONTRIBUTING.md
- [x] Updated plugin version number
- [ ] Added migrations
- [ ] Updated screenshots in assets folder
- [ ] Updated translations

**After PR merge**

- [ ] Released new version in GitHub
- [ ] Updated plugin on the PrestaShop Addons Marketplace
- [ ] Pinged code owners to inform marketing about new version
