### PR TITLE
abandoned-cart: Add mandatory fields to request payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 2.1.1
+
+Adds `is_abandoned_cart` field to abandoned cart request payload
+Does not opt-in unsubscribed customers who have received abandoned cart email
+
 ### 2.1.0
 
 Improving customers synchronization by including subscribers from `ps_emailsubscription` table to subscriber synchronization. [#60](https://github.com/sendsmaily/smaily-prestashop-module/pull/60)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Customer first name: `{{ first_name }}`.
 
 Customer last name: `{{ last_name }}`.
 
+Is abandoned cart: `{{ is_abandoned_cart }}`.
+
 Up to 10 products can be received in the Smaily templating engine. You can reference each product with a number 1-10 behind the parameter name.
 
 Product name: `{{ product_name_[1-10] }}`.

--- a/src/smailyforprestashop.php
+++ b/src/smailyforprestashop.php
@@ -39,7 +39,7 @@ class SmailyForPrestaShop extends Module
         $this->name = 'smailyforprestashop';
         $this->tab = 'advertising_marketing';
         $this->module_key = 'bcea90ce4da2594c0d0179852db9a1e3';
-        $this->version = '2.1.0';
+        $this->version = '2.1.1';
         $this->author = 'Smaily';
         $this->need_instance = 0;
         $this->ps_versions_compliancy = [

--- a/src/src/Controller/AbandonedCartController.php
+++ b/src/src/Controller/AbandonedCartController.php
@@ -171,6 +171,8 @@ class AbandonedCartController
     {
         $payload = [
             'email' => $cart->email,
+            'is_abandoned_cart' => 'true',
+            'force_opt_in' => false,
         ];
 
         $syncAdditional = json_decode($this->configuration->get('SMAILY_CART_SYNCRONIZE_ADDITIONAL'), true);


### PR DESCRIPTION
# Plugin Version : 2.1.1

**Version changelog**

A list of changes regarding the next version release:

1. Adds `is_abandoned_cart` field to request payload to better filter abandoned cart email receivers in Smaily.
2. Stops subscribing unsubscribed customers who have received an abandoned cart email.

**Release checklist**

- [x] Added `release` tag to this pull request
- [x] Updated README.md
- [x] Updated CHANGELOG.md
- [ ] Updated USERGUIDE.md
- [ ] Updated CONTRIBUTING.md
- [x] Updated plugin version number
- [ ] Added migrations
- [ ] Updated screenshots in assets folder
- [ ] Updated translations

**After PR merge**

- [x] Released new version in GitHub
- [ ] Updated plugin on the PrestaShop Addons Marketplace
- [x] Pinged code owners to inform marketing about new version
